### PR TITLE
Security Fix for Command Injection in jake: Replace execSync with execFileSync

### DIFF
--- a/lib/publish_task.js
+++ b/lib/publish_task.js
@@ -18,7 +18,7 @@
 
 let fs = require('fs');
 let path = require('path');
-let exec = require('child_process').execSync;
+let execFile = require('child_process').execFileSync;
 let FileList = require('filelist').FileList;
 
 let PublishTask = function () {
@@ -103,13 +103,13 @@ PublishTask.prototype = new (function () {
     namespace('publish', function () {
       task('fetchTags', function () {
         // Make sure local tags are up to date
-        exec(self.gitCmd + ' fetch --tags');
+        execFile(self.gitCmd, ['fetch', '--tags']);
         console.log('Fetched remote tags.');
       });
 
       task('getCurrentBranch', function () {
         // Figure out what branch to push to
-        let stdout = exec(self.gitCmd + ' symbolic-ref --short HEAD').toString();
+        let stdout = execFile(self.gitCmd, ['symbolic-ref', '--short', 'HEAD']).toString(); 
         if (!stdout) {
           throw new Error('No current Git branch found');
         }
@@ -119,7 +119,7 @@ PublishTask.prototype = new (function () {
 
       task('ensureClean', function () {
         // Only bump, push, and tag if the Git repo is clean
-        let stdout = exec(self.gitCmd + ' status --porcelain --untracked-files=no').toString();
+        let stdout = execFile(self.gitCmd, ['status', '--porcelain', '--untracked-files=no']).toString(); 
         // Throw if there's output
         self._ensureRepoClean(stdout);
       });
@@ -155,14 +155,14 @@ PublishTask.prototype = new (function () {
       task('pushVersion', ['ensureClean', 'updateVersionFiles'], function () {
         let version = getPackageVersionNumber();
         let message = 'Version ' + version;
-        let cmds = [
-          self.gitCmd + ' commit -a -m "' + message + '"',
-          self.gitCmd + ' push origin ' + _currentBranch,
-          self.gitCmd + ' tag -a v' + version + ' -m "' + message + '"',
-          self.gitCmd + ' push --tags'
+        let args = [
+          ['commit','-a','-m','"'+message+'"'],
+          ['push','origin',_currentBranch],
+          ['tag','-a','v'+version,'-m','"'+message+'"'],
+          ['push','--tags']
         ];
-        cmds.forEach((cmd) => {
-          exec(cmd);
+        args.forEach((arg) => {
+          execFile(self.gitCmd, arg);
         });
         version = getPackageVersionNumber();
         console.log('Bumped version number to v' + version + '.');
@@ -216,7 +216,7 @@ PublishTask.prototype = new (function () {
           }
           else {
             filename = './pkg/' + self.name + '-v' + version + '.tar.gz';
-            cmd = self.publishCmd.replace(/%filename/gi, filename);
+            cmd = self.publishCmd.replace(/%filename/gi, filename).split(/(\s+)/).filter( function(e) { return e.trim().length > 0; } );
           }
 
           if (typeof cmd == 'function') {
@@ -233,7 +233,7 @@ PublishTask.prototype = new (function () {
             // Error sending version data\nnpm ERR!
             // Error: forbidden 0.2.4 is modified, should match modified time
             setTimeout(function () {
-              let stdout = exec(cmd).toString() || '';
+              let stdout = execFile(cmd[0], cmd.slice(1,cmd.length)).toString().replace(/\'/g,"") || '';
               stdout = stdout.trim();
               if (stdout) {
                 console.log(stdout);


### PR DESCRIPTION
### 📊 Metadata *

Jake -- the JavaScript build tool for Node.js.

Jake is the JavaScript build tool for NodeJS. Jake has been around since the very early days of Node, and is full featured and well tested.

It has capabilities similar to GNU Make, CMake, or Rake in the Ruby community.

Similar tools in the Node and JavaScript ecosystem are Grunt and Gulp.

The jake publishTask is vulnerable to command injection and can cause arbitrary code execution, possibly leading to malware propagation via the jake toolchain.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-jake/

### ⚙️ Description *

Used child_process.execFileSync() to replace child_process.execSync().

### 💻 Technical Description *

The use of the child_process function execSync() is highly discouraged if you accept user input and don't sanitize/escape them. This PR replaces it with execFileSync() which mitigates any possible Command Injections as it accepts input as arrays. 

### 🐛 Proof of Concept (PoC) *

Create jakefile.js with the contents below:

//jakefile.js

let { publishTask } = require('jake');

publishTask('abc', {gitCmd: '$(touch pzhou@shu);'}, () => {});

//end of jakefile.js

run 'jake publish fetchTags' in your terminal, then the file pzhou@shu can be illegally created.

Note that, we can replace 'touch pzhou@shu' with any other OS command to execute.

### 🔥 Proof of Fix (PoF) *

After the fix run 'jake publish fetchTags' with the jakefile.js below can no longer create the illegal file pzhou@shu.

//jakefile.js

let { publishTask } = require('jake');

publishTask('abc', {gitCmd: '$(touch pzhou@shu);'}, () => {});

//end of jakefile.js  

### 👍 User Acceptance Testing (UAT)
npm test
> jake@10.8.2 test
> ./bin/cli.js test

Starting 'test:unit'...
Finished 'test:unit' after 2 ms
Starting 'publish:package'...
Created package for jake v10.8.2
Starting 'clobberPackage'...
Finished 'clobberPackage' after 1 ms
Starting 'pkg/jake-v10.8.2'...
Finished 'pkg/jake-v10.8.2' after 15 ms
Starting '/home/pengzh/projects/aphci/aphci_vul_finder/node_modules/jake/pkg/jake-v10.8.2.tar.gz'...
Finished '/home/pengzh/projects/aphci/aphci_vul_finder/node_modules/jake/pkg/jake-v10.8.2.tar.gz' after 13 ms
Starting 'buildPackage'...
Finished 'buildPackage' after 0 ms
Starting 'package'...
Finished 'package' after 0 ms
Finished 'publish:package' after 100 ms
Starting 'test:integration'...

  namespace
    ✓ resolve namespace by relative name
    ✓ resolve task in sub-namespace by relative path
    ✓ prefer local to top-level
    ✓ does resolve top-level
    ✓ absolute lookup works from sub-namespaces
    ✓ resolution miss with throw error

  parseargs
    ✓ long preemptive opt and val with equal-sign, ignore further opts
    ✓ long preemptive opt and val without equal-sign, ignore further opts
    ✓ long preemptive opt and no val, ignore further opts
    ✓ preemptive opt with no val, should be true
    ✓ preemptive opt with no val, should be true and ignore further opts
    ✓ preemptive opt with val, should be val
    ✓ -f expects a value, -t does not (howdy is task-name)
    ✓ different order, -f expects a value, -t does not (howdy is task-name)
    ✓ -f expects a value, -t does not (foo=bar is env var)
    ✓ -f expects a value, -t does not (foo=bar is env-var, task-name follows)
    ✓ -t does not expect a value, -f does (howdy is task-name)
    ✓ --trace does not expect a value, -f does (howdy is task-name)
    ✓ --trace does not expect a value (equal), -f does (throw howdy away)

  19 passing (6ms)

  concurrent
    ✓  simple concurrent prerequisites 1 (1608ms)
    ✓  simple concurrent prerequisites 2 (1697ms)
    ✓  sequential concurrent prerequisites (1955ms)
    ✓  concurrent concurrent prerequisites (1695ms)
    ✓  concurrent prerequisites with subdependency (1631ms)
    ✓  failing in concurrent prerequisites (1340ms)

  fileTask
    ✓ where a file-task prereq does not change with --always-make (2615ms)
    ✓ concating two files (1302ms)
    ✓ where a file-task prereq does not change (2588ms)
    ✓ where a file-task prereq does change, then does not (3602ms)
    ✓ a preexisting file (2597ms)
    ✓ a preexisting file with --always-make flag (2599ms)
    ✓ nested directory-task (1298ms)

  fileUtils
    ✓ mkdirP
    ✓ rmRf
    ✓ rmRf with symlink subdir
    ✓ rmRf with symlinked dir
    ✓ cpR with same name and different directory
    ✓ cpR with same to and from will throw
    ✓ cpR rename via copy in directory
    ✓ cpR rename via copy in base
    ✓ cpR keeps file mode
    ✓ cpR keeps file mode when overwriting with preserveMode
    ✓ cpR does not keep file mode when overwriting
    ✓ cpR copies file mode recursively
    ✓ cpR keeps file mode recursively
    ✓ cpR copies directory mode recursively

  publishTask
    ✓ default task (1474ms)

  rule
    ✓ Rule.getSource
    ✓ rule w/o pattern (1308ms)
    ✓ rule w pattern w/o folder w/o namespace (1460ms)
    ✓ rule w pattern w folder w/o namespace (1336ms)
    - rule w pattern w folder w namespace
    - rule w chain w pattern w folder w namespace
    ✓ rule with source file not created yet (precedence) (1308ms)
    ✓ rule with source file now created (precedence) (1305ms)
    ✓ rule with source file modified (precedence) (2322ms)
    ✓ rule with existing objective file and no source  (should be normal file-task) (precedence) (1305ms)
    ✓ rule with source file not created yet (regexPattern) (1303ms)
    ✓ rule with source file now created (regexPattern) (1296ms)
    ✓ rule with source file modified (regexPattern) (2308ms)
    ✓ rule with existing objective file and no source  (should be normal file-task) (regexPattern) (1310ms)
    ✓ rule with source file not created yet (sourceFunction) (1300ms)
    ✓ rule with source file now created (sourceFunction) (1315ms)
    ✓ rule with source file modified (sourceFunction) (2349ms)
    ✓ rule with existing objective file and no source  (should be normal file-task) (sourceFunction) (1307ms)

  selfDep
    ✓ self dep const (1311ms)
    ✓ self dep dyn (1301ms)

  taskBase
    ✓ default task (2598ms)
    ✓ task with no action (1367ms)
    ✓ a task with no action and no prereqs (1293ms)
    ✓ a task that exists at the top-level, and not in the specified namespace, should error (1295ms)
    ✓ passing args to a task (1289ms)
    ✓ a task with environment vars (1296ms)
    ✓ passing args and using environment vars (1295ms)
    ✓ a simple prereq (1308ms)
    ✓ a duplicate prereq only runs once (1299ms)
    ✓ a prereq with command-line args (1315ms)
    ✓ a prereq with args via invoke (1412ms)
    ✓ a prereq with args via execute (1344ms)
    ✓ repeating the task via execute (1312ms)
    ✓ prereq execution-order (1307ms)
    ✓ basic async task (1320ms)
    ✓ promise async task (1302ms)
    ✓ failing promise async task (1309ms)
    ✓ that current-prereq index gets reset (1310ms)
    ✓ modifying a task by adding prereq during execution (1312ms)
    ✓ listening for task error-event (1310ms)
    ✓ listening for jake error-event (1306ms)
    ✓ listening for jake unhandledRejection-event (1323ms)
    ✓ large number of same prereqs (1413ms)
    ✓ large number of different prereqs (1423ms)
    ✓ large number of different prereqs (1335ms)
    ✓ modifying a namespace by adding a new task (1296ms)

  72 passing (1m)
  2 pending

Finished 'test:integration' after 89401 ms
Starting 'test'...
Finished 'test' after 0 ms

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1966
