### PR TITLE
Fix Command Injection in packageTask

### DIFF
--- a/lib/package_task.js
+++ b/lib/package_task.js
@@ -18,7 +18,7 @@
 
 let path = require('path');
 let fs = require('fs');
-let exec = require('child_process').exec;
+let exec = require('child_process').execFile;
 let FileList = require('filelist').FileList;
 
 /**
@@ -286,8 +286,7 @@ PackageTask.prototype = new (function () {
           archiveContentDir = self.archiveContentDir;
         }
 
-        cmd = self[opts.cmd + 'Command'];
-        cmd += ' -' + opts.flags;
+        cmd = '-' + opts.flags;
         if (opts.cmd == 'jar' && self.manifestFile) {
           cmd += 'm';
         }
@@ -324,7 +323,7 @@ PackageTask.prototype = new (function () {
         // Return back up to the current dir after the exec
         process.chdir(chdir);
 
-        exec(cmd, function (err, stdout, stderr) {
+        exec(self[opts.cmd + 'Command'], cmd.split(" "), function (err, stdout, stderr) {
           if (err) { throw err; }
 
           // Return back up to the starting directory (see above,


### PR DESCRIPTION
### 📊 Metadata *

`jake` is vulnerable to `Command Injection vulnerability`. It allows attackers to execute arbitrary OS commands.

#### Bounty URL: https://www.huntr.dev/bounties/2-npm-jake

### ⚙️ Description *

The `exec` function is not sanitizing characters which are interpreted as an OS command.

### 💻 Technical Description *

As this application uses `exec` function to compact files (zip, tar, etc), the fix replaces the function `exec` to `execFile`, which is possible to define a specific command and isolate the user input without executing OS commands. Example:
```javascript
execFile("zip", ["arguments"])
```

### 🐛 Proof of Concept (PoC) *

Create the following PoC file as `jakefile.js`:
```javascript
const { packageTask } = require('jake');
const command = "$(touch poc.js)";
package = new packageTask(command, 'v1.0');
package.needTar = true;
package.define();
```

Execute: `jake package -f jakefile.js`.

Look inside the pkg directory created and check that has a poc.js file.

### 🔥 Proof of Fix (PoF) *

After executing the PoC, the  `poc.js` file will not be created.

### 👍 User Acceptance Testing (UAT)

Normal execution:
```javascript
const { packageTask } = require('jake');
package = new packageTask("test", 'v1.0');
package.needTar = true;
package.define();
```

### 🔗 Relates to...

https://github.com/418sec/curling/pull/2